### PR TITLE
Allow Windows 10 (in io.js > 3.0) to use fancy symbols

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 'use strict';
 var platform = process.platform;
+var os = require('os');
 
 var main = {
 	tick: '✔',
@@ -84,4 +85,17 @@ if (platform === 'linux') {
   main.questionMarkPrefix = '?';
 }
 
-module.exports = platform === 'win32' ? win : main;
+var useMainSymbols = false;
+if (platform === 'win32') {
+	var version = os.release().match(/(\d+)/);
+	var major = parseInt(version[1]);
+
+	// Windows 10+
+	if (major >= 10) {
+		useMainSymbols = true;
+	}
+} else {
+	useMainSymbols = true;
+}
+
+module.exports = useMainSymbols ? main : win;


### PR DESCRIPTION
This commit adds Windows version detection and switches to Unicode symbols on Windows 10+, since it has a Unicode-enabled font by default.

This won't kick in until a release after io.js 3.0, but I've submitted a PR to fix the functionality and properly detect Windows 10 with `os.release()`.

Ideally, this library would use feature detection, but I researched it and that's non-trivial here.