### PR TITLE
add list of figures in readme - fixes #17

### DIFF
--- a/makefile.js
+++ b/makefile.js
@@ -1,0 +1,28 @@
+#!/usr/bin/env node
+'use strict';
+const fs = require('fs');
+const requireUncached = require('require-uncached');
+const table = require('markdown-table');
+
+const load = value => {
+	Object.defineProperty(process, 'platform', {value});
+	return requireUncached('./');
+};
+
+const darwin = load('darwin');
+const win32 = load('win32');
+
+const jsonTable = [
+	['Name', 'Real OSes', 'Windows']
+];
+
+Object.keys(darwin).forEach(key => {
+	jsonTable.push([key, darwin[key], win32[key]]);
+});
+
+const figureTable = table(jsonTable, {align: ['', 'c', 'c']});
+
+let readme = fs.readFileSync('readme.md', 'utf8');
+readme = readme.replace(/## Figures[^#]*/gm, `## Figures\n\n${figureTable}\n\n\n`);
+
+fs.writeFileSync('readme.md', readme);

--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
     "node": ">=0.10.0"
   },
   "scripts": {
-    "prepublish": "npm run make",
     "test": "xo && ava",
     "make": "./makefile.js"
   },

--- a/package.json
+++ b/package.json
@@ -13,7 +13,9 @@
     "node": ">=0.10.0"
   },
   "scripts": {
-    "test": "xo && ava"
+    "prepublish": "npm run make",
+    "test": "xo && ava",
+    "make": "./makefile.js"
   },
   "files": [
     "index.js"
@@ -37,6 +39,8 @@
   },
   "devDependencies": {
     "ava": "*",
+    "markdown-table": "^0.4.0",
+    "require-uncached": "^1.0.2",
     "xo": "*"
   }
 }

--- a/readme.md
+++ b/readme.md
@@ -46,6 +46,68 @@ Type: `string`
 String where the unicode symbols will be replaced with fallback symbols depending on the OS.
 
 
+## Figures
+
+| Name               | Real OSes | Windows |
+| ------------------ | :-------: | :-----: |
+| tick               |     ✔     |    √    |
+| cross              |     ✖     |    ×    |
+| star               |     ★     |    *    |
+| square             |     ▇     |    █    |
+| squareSmall        |     ◻     |   [ ]   |
+| squareSmallFilled  |     ◼     |   [█]   |
+| play               |     ▶     |    ►    |
+| circle             |     ◯     |   ( )   |
+| circleFilled       |     ◉     |   (*)   |
+| circleDotted       |     ◌     |   ( )   |
+| circleDouble       |     ◎     |   ( )   |
+| circleCircle       |     ⓞ     |   (○)   |
+| circleCross        |     ⓧ     |   (×)   |
+| circlePipe         |     Ⓘ     |   (│)   |
+| circleQuestionMark |     ?⃝    |   (?)   |
+| bullet             |     ●     |    *    |
+| dot                |     ․     |    .    |
+| line               |     ─     |    ─    |
+| ellipsis           |     …     |   ...   |
+| pointer            |     ❯     |    >    |
+| pointerSmall       |     ›     |    »    |
+| info               |     ℹ     |    i    |
+| warning            |     ⚠     |    ‼    |
+| hamburger          |     ☰     |    ≡    |
+| smiley             |     ㋡     |    ☺    |
+| mustache           |     ෴     |   ┌─┐   |
+| heart              |     ♥     |    ♥    |
+| arrowUp            |     ↑     |    ↑    |
+| arrowDown          |     ↓     |    ↓    |
+| arrowLeft          |     ←     |    ←    |
+| arrowRight         |     →     |    →    |
+| radioOn            |     ◉     |   (*)   |
+| radioOff           |     ◯     |   ( )   |
+| checkboxOn         |     ☒     |   [×]   |
+| checkboxOff        |     ☐     |   [ ]   |
+| checkboxCircleOn   |     ⓧ     |   (×)   |
+| checkboxCircleOff  |     Ⓘ     |   ( )   |
+| questionMarkPrefix |     ?⃝    |    ？    |
+| oneHalf            |     ½     |   1/2   |
+| oneThird           |     ⅓     |   1/3   |
+| oneQuarter         |     ¼     |   1/4   |
+| oneFifth           |     ⅕     |   1/5   |
+| oneSixth           |     ⅙     |   1/6   |
+| oneSeventh         |     ⅐     |   1/7   |
+| oneEighth          |     ⅛     |   1/8   |
+| oneNinth           |     ⅑     |   1/9   |
+| oneTenth           |     ⅒     |   1/10  |
+| twoThirds          |     ⅔     |   2/3   |
+| twoFifths          |     ⅖     |   2/5   |
+| threeQuarters      |     ¾     |   3/4   |
+| threeFifths        |     ⅗     |   3/5   |
+| threeEighths       |     ⅜     |   3/8   |
+| fourFifths         |     ⅘     |   4/5   |
+| fiveSixths         |     ⅚     |   5/6   |
+| fiveEighths        |     ⅝     |   5/8   |
+| sevenEighths       |     ⅞     |   7/8   |
+
+
 ## License
 
 MIT © [Sindre Sorhus](https://sindresorhus.com)


### PR DESCRIPTION
Added a `makefile.js` script that retrieves the figures from the module and adds them to the readme. The script also executes on `prepublish` to make sure it is executed before released to `npm`.

If you rather give it another name, suggestions are welcome :).