### PR TITLE
Detect new Windows terminal

### DIFF
--- a/index.js
+++ b/index.js
@@ -126,7 +126,13 @@ if (platform === 'linux') {
 	main.questionMarkPrefix = '?';
 }
 
-const figures = platform === 'win32' ? windows : main;
+const figures = platform === 'win32' ? process.env.WT_SESSION ? main : windows : main;
+
+if (platform === 'win32' && process.env.WT_SESSION) {
+	// The main ones doesn't look that good on Ubuntu
+	main.questionMarkPrefix = '?';
+	main.circleQuestionMark = '(?)';
+}
 
 const fn = string => {
 	if (figures === main) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "figures",
-	"version": "3.0.0",
+	"version": "3.1.0",
 	"description": "Unicode symbols with Windows CMD fallbacks",
 	"license": "MIT",
 	"repository": "sindresorhus/figures",

--- a/readme.md
+++ b/readme.md
@@ -7,6 +7,7 @@
 [*and more...*](index.js)
 
 Windows CMD only supports a [limited character set](http://en.wikipedia.org/wiki/Code_page_437).
+The new Windows terminal fully supports Unicode symbols.
 
 
 ## Install

--- a/test.js
+++ b/test.js
@@ -1,7 +1,7 @@
 import test from 'ava';
 import figures from '.';
 
-const result = (main, windows) => process.platform === 'win32' ? windows : main;
+const result = (main, windows) => process.platform === 'win32' ? process.env.WT_SESSION ? main : windows : main;
 
 console.log('  ' + Object.keys(figures).map(symbol => figures[symbol]).join('  ') + '\n');
 


### PR DESCRIPTION
The new Windows terminal fully supports Unicode symbols, sadly there is no
proper way to identify it yet. https://github.com/microsoft/terminal/issues/1040
exists to tackle this issue, in the meantime every terminal session has a unique
env variable ```WT_SESSION``` which can be used to detect the terminal type.

If you are okay with this PR as it is, or if you want to wait until a proper
detection method is implemented, please let me know.