### PR TITLE
feat: Support new Windows Terminal

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 'use strict';
 const escapeStringRegexp = require('escape-string-regexp');
 
-const {platform, env} = process;
+const { platform, env } = process;
 
 const main = {
 	tick: '✔',
@@ -128,7 +128,7 @@ if (platform === 'linux') {
 	main.questionMarkPrefix = '?';
 }
 
-const figures = platform === 'win32' || !env.WT_SESSION ? windows : main;
+const figures = platform === 'win32' && !env.WT_SESSION ? windows : main;
 
 const fn = string => {
 	if (figures === main) {

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 'use strict';
 const escapeStringRegexp = require('escape-string-regexp');
 
-const {platform} = process;
+const {platform, env} = process;
 
 const main = {
 	tick: '✔',
@@ -128,7 +128,7 @@ if (platform === 'linux') {
 	main.questionMarkPrefix = '?';
 }
 
-const figures = platform === 'win32' ? windows : main;
+const figures = platform === 'win32' || !env.WT_SESSION ? windows : main;
 
 const fn = string => {
 	if (figures === main) {

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 'use strict';
 const escapeStringRegexp = require('escape-string-regexp');
 
-const { platform, env } = process;
+const {platform, env} = process;
 
 const main = {
 	tick: '✔',


### PR DESCRIPTION
An upcoming feature of the Windows Terminal preview is that it has full emoji support:

[![Windows Powershell running in Windows Terminal][1]][1]

  [1]: https://i.stack.imgur.com/7YuSI.png

In this PR, the code now checks for the `WT_SESSION` variable which [determines if the current environment is in the Windows Terminal](https://github.com/microsoft/terminal/issues/2256#issuecomment-518303072).

A few other concerns:

The full check has been continuously getting out of sync with https://github.com/sindresorhus/log-symbols/blob/master/index.js#L4 so we should probably make a lego brick for this one. I'll make it if you want.

The variable name `windows` is now slightly misleading since now it only targets *unsupported* terminals so we should probably rename it to `legacy`.

cc @sindresorhus 