### PR TITLE
feat: display fancy figures on Windows Terminal

### DIFF
--- a/index.js
+++ b/index.js
@@ -128,7 +128,7 @@ if (platform === 'linux') {
 	main.questionMarkPrefix = '?';
 }
 
-const figures = platform === 'win32' ? windows : main;
+const figures = platform === 'win32' && !process.env.WT_SESSION ? windows : main;
 
 const fn = string => {
 	if (figures === main) {


### PR DESCRIPTION
On `conhost.exe`, these characters were not supported. But on Windows Terminal, they are. The Windows Terminal adds the [`WT_SESSION`](https://github.com/microsoft/terminal/issues/840) environment variable, which allows to identify when it's used. Thanks to that, we can now display fancy figures on Windows. 

This change updates the previous behavior by adding an additional check against the `WT_SESSION` environment variable, in order to allow these characters on the Windows Terminal.

![](https://i.imgur.com/KDTWdD5.png)