### PR TITLE
Improve `bullet` figure

### DIFF
--- a/index.js
+++ b/index.js
@@ -79,7 +79,7 @@ const fallback = {
 	circleCross: '(×)',
 	circlePipe: '(│)',
 	circleQuestionMark: '(?)',
-	bullet: '*',
+	bullet: main.bullet,
 	dot: '.',
 	line: '─',
 	ellipsis: '...',

--- a/readme.md
+++ b/readme.md
@@ -78,7 +78,7 @@ Symbols to use when running on Windows.
 | circleCross        |      ⓧ      |   (×)   |
 | circlePipe         |      Ⓘ      |   (│)   |
 | circleQuestionMark |      ?⃝     |   (?)   |
-| bullet             |      ●      |    *    |
+| bullet             |      ●      |    ●    |
 | dot                |      ․      |    .    |
 | line               |      ─      |    ─    |
 | ellipsis           |      …      |   ...   |


### PR DESCRIPTION
The `bullet` figure `U-25cf` `●` displays correctly on Windows, is there a reason to use `*` instead?

Ubuntu 20.10 Gnome terminal:

![unix_1](https://user-images.githubusercontent.com/8136211/112217267-b8139580-8c22-11eb-8384-b97cb8991dfc.png)

Windows 10 `cmd.exe` (CP850):

![windows_1](https://user-images.githubusercontent.com/8136211/112217170-9dd9b780-8c22-11eb-9497-9e293a2cfada.png)
