### PR TITLE
Improve `dot` figure

### DIFF
--- a/index.js
+++ b/index.js
@@ -82,7 +82,7 @@ const fallback = {
 	circlePipe: '(│)',
 	circleQuestionMark: '(?)',
 	bullet: main.bullet,
-	dot: '.',
+	dot: main.dot,
 	line: main.line,
 	ellipsis: '...',
 	pointer: '>',

--- a/readme.md
+++ b/readme.md
@@ -79,7 +79,7 @@ Symbols to use when running on Windows.
 | circlePipe         |      Ⓘ      |   (│)   |
 | circleQuestionMark |      ?⃝     |   (?)   |
 | bullet             |      ●      |    ●    |
-| dot                |      ․      |    .    |
+| dot                |      ․      |    ․    |
 | line               |      ─      |    ─    |
 | ellipsis           |      …      |   ...   |
 | pointer            |      ❯      |    >    |


### PR DESCRIPTION
The `dot` figure `U-2024` `․` displays correctly on Windows, is there a reason to use the ASCII dot `.` instead?

Ubuntu 20.10 Gnome terminal:

![unix_1](https://user-images.githubusercontent.com/8136211/112217267-b8139580-8c22-11eb-8384-b97cb8991dfc.png)

Windows 10 `cmd.exe` (CP850):

![windows_1](https://user-images.githubusercontent.com/8136211/112217170-9dd9b780-8c22-11eb-9497-9e293a2cfada.png)
