### PR TITLE
Improve `ellipsis` figure

### DIFF
--- a/index.js
+++ b/index.js
@@ -84,7 +84,7 @@ const fallback = {
 	bullet: main.bullet,
 	dot: '.',
 	line: main.line,
-	ellipsis: '...',
+	ellipsis: main.ellipsis,
 	pointer: '>',
 	pointerSmall: main.pointerSmall,
 	info: 'i',

--- a/readme.md
+++ b/readme.md
@@ -81,7 +81,7 @@ Symbols to use when running on Windows.
 | bullet             |      ●      |    ●    |
 | dot                |      ․      |    .    |
 | line               |      ─      |    ─    |
-| ellipsis           |      …      |   ...   |
+| ellipsis           |      …      |    …    |
 | pointer            |      ❯      |    >    |
 | pointerSmall       |      ›      |    ›    |
 | info               |      ℹ      |    i    |


### PR DESCRIPTION
The `ellipsis` figure `U-2026` `…` displays correctly on Windows, is there a reason to use the ASCII dots `...` instead?

Ubuntu 20.10 Gnome terminal:

![unix_1](https://user-images.githubusercontent.com/8136211/112217267-b8139580-8c22-11eb-8384-b97cb8991dfc.png)

Windows 10 `cmd.exe` (CP850):

![windows_1](https://user-images.githubusercontent.com/8136211/112217170-9dd9b780-8c22-11eb-9497-9e293a2cfada.png)
