### PR TITLE
Improve `pointerSmall` figure

### DIFF
--- a/index.js
+++ b/index.js
@@ -84,7 +84,7 @@ const fallback = {
 	line: '─',
 	ellipsis: '...',
 	pointer: '>',
-	pointerSmall: '»',
+	pointerSmall: main.pointerSmall,
 	info: 'i',
 	warning: '‼',
 	hamburger: '≡',

--- a/readme.md
+++ b/readme.md
@@ -83,7 +83,7 @@ Symbols to use when running on Windows.
 | line               |      ─      |    ─    |
 | ellipsis           |      …      |   ...   |
 | pointer            |      ❯      |    >    |
-| pointerSmall       |      ›      |    »    |
+| pointerSmall       |      ›      |    ›    |
 | info               |      ℹ      |    i    |
 | warning            |      ⚠      |    ‼    |
 | hamburger          |      ☰      |    ≡    |


### PR DESCRIPTION
The `pointerSmall` figure `U-203a` `›` displays correctly on Windows, is there a reason to use `U-00bb` `»` instead?

Note: the `pointer` figure `U-276f` `❯` does not display correctly, and the best replacement seems to be ASCII `>` (currently used). However, the difference of size with `pointerSmall` seems good enough in both cases.

Ubuntu 20.10 Gnome terminal:

![unix_2](https://user-images.githubusercontent.com/8136211/112218524-18570700-8c24-11eb-9bc9-86e9663e45c6.png)

Windows 10 `cmd.exe` (CP850):

![windows_2](https://user-images.githubusercontent.com/8136211/112218534-1d1bbb00-8c24-11eb-902e-9f045c4ef090.png)
