### PR TITLE
Improve the `star` figure

### DIFF
--- a/index.js
+++ b/index.js
@@ -66,7 +66,7 @@ const main = {
 const fallback = {
 	tick: '√',
 	cross: '×',
-	star: '*',
+	star: '✶',
 	square: '█',
 	squareSmall: '[ ]',
 	squareSmallFilled: '[█]',

--- a/readme.md
+++ b/readme.md
@@ -65,7 +65,7 @@ Symbols to use when running on Windows.
 | ------------------ | :---------: | :-----: |
 | tick               |      ✔      |    √    |
 | cross              |      ✖      |    ×    |
-| star               |      ★      |    *    |
+| star               |      ★      |    ✶    |
 | square             |      ▇      |    █    |
 | squareSmall        |      ◻      |   [ ]   |
 | squareSmallFilled  |      ◼      |   [█]   |

--- a/test.js
+++ b/test.js
@@ -13,8 +13,8 @@ test('fallbacks', t => {
 	t.is(figures('foo'), 'foo');
 	t.is(figures('?bar?'), '?bar?');
 	t.is(figures('✔ ✔ ✔'), result('✔ ✔ ✔', '√ √ √'));
-	t.is(figures('✔ ✖\n★ ▇'), result('✔ ✖\n★ ▇', '√ ×\n* █'));
-	t.is(figures('✔ ✖ ★ ▇'), result('✔ ✖ ★ ▇', '√ × * █'));
+	t.is(figures('✔ ✖\n★ ▇'), result('✔ ✖\n★ ▇', '√ ×\n✶ █'));
+	t.is(figures('✔ ✖ ★ ▇'), result('✔ ✖ ★ ▇', '√ × ✶ █'));
 });
 
 test('exported sets', t => {


### PR DESCRIPTION
This improves the `star` figure on Windows CP850 by using `U-2736` `✶` instead of ASCII `*`.

Ubuntu 20.10 Gnome terminal:

![unix_4](https://user-images.githubusercontent.com/8136211/112219297-15a8e180-8c25-11eb-8d26-2f6b095c03bd.png)

Windows 10 `cmd.exe` (CP850):

![windows_4](https://user-images.githubusercontent.com/8136211/112219313-193c6880-8c25-11eb-9b8c-04e563869b19.png)
