### PR TITLE
Use `main.line` instead of repeating character

### DIFF
--- a/index.js
+++ b/index.js
@@ -81,7 +81,7 @@ const fallback = {
 	circleQuestionMark: '(?)',
 	bullet: '*',
 	dot: '.',
-	line: '─',
+	line: main.line,
 	ellipsis: '...',
 	pointer: '>',
 	pointerSmall: '»',


### PR DESCRIPTION
Background at https://github.com/sindresorhus/figures/pull/36#discussion_r600462609

This uses `main.*` to make it clearer that the Windows and non-Windows variants of the `line` figure are the same Unicode codepoint.