### PR TITLE
Fix `circleQuestionMark` character does not display properly on Ubuntu

### DIFF
--- a/index.js
+++ b/index.js
@@ -129,6 +129,7 @@ const fallback = {
 
 if (platform === 'linux') {
 	// The main one doesn't look that good on Ubuntu.
+	main.circleQuestionMark = '?';
 	main.questionMarkPrefix = '?';
 }
 


### PR DESCRIPTION
e97270a8858dd824135962db5b7d940b00a94a41 added both `circleQuestionMark` and `questionMarkPrefix`, with the same Unicode codepoints.

It added a fallback for `questionMarkPrefix` on Linux to not looking good on Ubuntu. However, it seems like this should apply to `circleQuestionMark` as well.

This is how this looks like before this fix on Ubuntu 20.10 (Gnome terminal):

![question_mark](https://user-images.githubusercontent.com/8136211/112333132-9ebe2800-8cba-11eb-9cd8-f5c48631a533.png)

After this fix, both characters are the same as the left one.