### PR TITLE
Add a test validating figures are non-empty strings

### DIFF
--- a/test.js
+++ b/test.js
@@ -21,3 +21,15 @@ test('exported sets', t => {
 	t.is(figures.main.tick, '✔');
 	t.is(figures.windows.tick, '√');
 });
+
+const NON_FIGURE_KEYS = new Set(['main', 'windows']);
+
+test('figures are non-empty strings', t => {
+	for (const [key, figure] of Object.entries(figures)) {
+		if (NON_FIGURE_KEYS.has(key)) {
+			continue;
+		}
+
+		t.true(typeof figure === 'string' && figure.trim() !== '');
+	}
+});


### PR DESCRIPTION
This adds a test validating that figures are defined, are strings and are non-empty.
The opposite could happen on typos for example.