### PR TITLE
Use code ticks around symbols in `readme.md`

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -63,95 +63,95 @@ Symbols to use when running on Windows.
 
 | Name               | Non-Windows | Windows |
 | ------------------ | :---------: | :-----: |
-| tick               |      ✔      |    √    |
-| cross              |      ✖      |    ×    |
-| star               |      ★      |    ✶    |
-| square             |      ▇      |    █    |
-| squareSmall        |      ◻      |    □    |
-| squareSmallFilled  |      ◼      |    ■    |
-| play               |      ▶      |    ►    |
-| circle             |      ◯      |   ( )   |
-| circleFilled       |      ◉      |   (*)   |
-| circleDotted       |      ◌      |   ( )   |
-| circleDouble       |      ◎      |   ( )   |
-| circleCircle       |      ⓞ      |   (○)   |
-| circleCross        |      ⓧ      |   (×)   |
-| circlePipe         |      Ⓘ      |   (│)   |
-| circleQuestionMark |      ?⃝     |   (?)   |
-| bullet             |      ●      |    ●    |
-| dot                |      ․      |    ․    |
-| line               |      ─      |    ─    |
-| ellipsis           |      …      |    …    |
-| pointer            |      ❯      |    >    |
-| pointerSmall       |      ›      |    ›    |
-| triangleUp         |      ▲      |    ▲    |
-| triangleUpSmall    |      ▴      |    ▴    |
-| triangleUpOutline  |      △      |    ∆    |
-| triangleDown       |      ▼      |    ▼    |
-| triangleDownSmall  |      ▾      |    ▾    |
-| triangleLeft       |      ◀      |    ◄    |
-| triangleLeftSmall  |      ◂      |    ◂    |
-| triangleRight      |      ▶      |    ►    |
-| triangleRightSmall |      ▸      |    ▸    |
-| lozenge            |      ◆      |    ♦    |
-| lozengeOutline     |      ◇      |    ◊    |
-| home               |      ⌂      |    ⌂    |
-| info               |      ℹ      |    i    |
-| warning            |      ⚠      |    ‼    |
-| hamburger          |      ☰      |    ≡    |
-| smiley             |      ㋡      |    ☺    |
-| mustache           |      ෴      |   ┌─┐   |
-| heart              |      ♥      |    ♥    |
-| musicNote          |      ♪      |    ♪    |
-| musicNoteBeamed    |      ♫      |    ♫    |
-| nodejs             |      ⬢      |    ♦    |
-| arrowUp            |      ↑      |    ↑    |
-| arrowDown          |      ↓      |    ↓    |
-| arrowLeft          |      ←      |    ←    |
-| arrowRight         |      →      |    →    |
-| arrowLeftRight     |      ↔      |    ↔    |
-| arrowUpDown        |      ↕      |    ↕    |
-| almostEqual        |      ≈      |    ≈    |
-| notEqual           |      ≠      |    ≠    |
-| lessOrEqual        |      ≤      |    ≤    |
-| greaterOrEqual     |      ≥      |    ≥    |
-| identical          |      ≡      |    ≡    |
-| infinity           |      ∞      |    ∞    |
-| radioOn            |      ◉      |   (*)   |
-| radioOff           |      ◯      |   ( )   |
-| checkboxOn         |      ☒      |   [×]   |
-| checkboxOff        |      ☐      |   [ ]   |
-| checkboxCircleOn   |      ⓧ      |   (×)   |
-| checkboxCircleOff  |      Ⓘ      |   ( )   |
-| questionMarkPrefix |      ?⃝     |    ？    |
-| subscriptZero      |      ₀      |    ₀    |
-| subscriptOne       |      ₁      |    ₁    |
-| subscriptTwo       |      ₂      |    ₂    |
-| subscriptThree     |      ₃      |    ₃    |
-| subscriptFour      |      ₄      |    ₄    |
-| subscriptFive      |      ₅      |    ₅    |
-| subscriptSix       |      ₆      |    ₆    |
-| subscriptSeven     |      ₇      |    ₇    |
-| subscriptEight     |      ₈      |    ₈    |
-| subscriptNine      |      ₉      |    ₉    |
-| oneHalf            |      ½      |    ½    |
-| oneThird           |      ⅓      |    ⅓    |
-| oneQuarter         |      ¼      |    ¼    |
-| oneFifth           |      ⅕      |    ⅕    |
-| oneSixth           |      ⅙      |    ⅙    |
-| oneSeventh         |      ⅐      |   1/7   |
-| oneEighth          |      ⅛      |    ⅛    |
-| oneNinth           |      ⅑      |   1/9   |
-| oneTenth           |      ⅒      |   1/10  |
-| twoThirds          |      ⅔      |    ⅔    |
-| twoFifths          |      ⅖      |    ⅖    |
-| threeQuarters      |      ¾      |    ¾    |
-| threeFifths        |      ⅗      |    ⅗    |
-| threeEighths       |      ⅜      |    ⅜    |
-| fourFifths         |      ⅘      |    ⅘    |
-| fiveSixths         |      ⅚      |    ⅚    |
-| fiveEighths        |      ⅝      |    ⅝    |
-| sevenEighths       |      ⅞      |    ⅞    |
+| tick               |     `✔`     |   `√`   |
+| cross              |     `✖`     |   `×`   |
+| star               |     `★`     |   `✶`   |
+| square             |     `▇`     |   `█`   |
+| squareSmall        |     `◻`     |   `□`   |
+| squareSmallFilled  |     `◼`     |   `■`   |
+| play               |     `▶`     |   `►`   |
+| circle             |     `◯`     |  `( )`  |
+| circleFilled       |     `◉`     |  `(*)`  |
+| circleDotted       |     `◌`     |  `( )`  |
+| circleDouble       |     `◎`     |  `( )`  |
+| circleCircle       |     `ⓞ`     |  `(○)`  |
+| circleCross        |     `ⓧ`     |  `(×)`  |
+| circlePipe         |     `Ⓘ`     |  `(│)`  |
+| circleQuestionMark |     `?⃝ `   |  `(?)`  |
+| bullet             |     `●`     |   `●`   |
+| dot                |     `․`     |   `․`   |
+| line               |     `─`     |   `─`   |
+| ellipsis           |     `…`     |   `…`   |
+| pointer            |     `❯`     |   `>`   |
+| pointerSmall       |     `›`     |   `›`   |
+| triangleUp         |     `▲`     |   `▲`   |
+| triangleUpSmall    |     `▴`     |   `▴`   |
+| triangleUpOutline  |     `△`     |   `∆`   |
+| triangleDown       |     `▼`     |   `▼`   |
+| triangleDownSmall  |     `▾`     |   `▾`   |
+| triangleLeft       |     `◀`     |   `◄`   |
+| triangleLeftSmall  |     `◂`     |   `◂`   |
+| triangleRight      |     `▶`     |   `►`   |
+| triangleRightSmall |     `▸`     |   `▸`   |
+| lozenge            |     `◆`     |   `♦`   |
+| lozengeOutline     |     `◇`     |   `◊`   |
+| home               |     `⌂`     |   `⌂`   |
+| info               |     `ℹ`     |   `i`   |
+| warning            |     `⚠`     |   `‼`   |
+| hamburger          |     `☰`     |   `≡`   |
+| smiley             |     `㋡`    |   `☺`   |
+| mustache           |     `෴`     |  `┌─┐`  |
+| heart              |     `♥`     |   `♥`   |
+| musicNote          |     `♪`     |   `♪`   |
+| musicNoteBeamed    |     `♫`     |   `♫`   |
+| nodejs             |     `⬢`     |   `♦`   |
+| arrowUp            |     `↑`     |   `↑`   |
+| arrowDown          |     `↓`     |   `↓`   |
+| arrowLeft          |     `←`     |   `←`   |
+| arrowRight         |     `→`     |   `→`   |
+| arrowLeftRight     |     `↔`     |   `↔`   |
+| arrowUpDown        |     `↕`     |   `↕`   |
+| almostEqual        |     `≈`     |   `≈`   |
+| notEqual           |     `≠`     |   `≠`   |
+| lessOrEqual        |     `≤`     |   `≤`   |
+| greaterOrEqual     |     `≥`     |   `≥`   |
+| identical          |     `≡`     |   `≡`   |
+| infinity           |     `∞`     |   `∞`   |
+| radioOn            |     `◉`     |  `(*)`  |
+| radioOff           |     `◯`     |  `( )`  |
+| checkboxOn         |     `☒`     |  `[×]`  |
+| checkboxOff        |     `☐`     |  `[ ]`  |
+| checkboxCircleOn   |     `ⓧ`     |  `(×)`  |
+| checkboxCircleOff  |     `Ⓘ`     |  `( )`  |
+| questionMarkPrefix |     `?⃝ `   |   `？`   |
+| subscriptZero      |     `₀`     |   `₀`   |
+| subscriptOne       |     `₁`     |   `₁`   |
+| subscriptTwo       |     `₂`     |   `₂`   |
+| subscriptThree     |     `₃`     |   `₃`   |
+| subscriptFour      |     `₄`     |   `₄`   |
+| subscriptFive      |     `₅`     |   `₅`   |
+| subscriptSix       |     `₆`     |   `₆`   |
+| subscriptSeven     |     `₇`     |   `₇`   |
+| subscriptEight     |     `₈`     |   `₈`   |
+| subscriptNine      |     `₉`     |   `₉`   |
+| oneHalf            |     `½`     |   `½`   |
+| oneThird           |     `⅓`     |   `⅓`   |
+| oneQuarter         |     `¼`     |   `¼`   |
+| oneFifth           |     `⅕`     |   `⅕`   |
+| oneSixth           |     `⅙`     |   `⅙`   |
+| oneSeventh         |     `⅐`     |  `1/7`  |
+| oneEighth          |     `⅛`     |   `⅛`   |
+| oneNinth           |     `⅑`     |  `1/9`  |
+| oneTenth           |     `⅒`     |  `1/10` |
+| twoThirds          |     `⅔`     |   `⅔`   |
+| twoFifths          |     `⅖`     |   `⅖`   |
+| threeQuarters      |     `¾`     |   `¾`   |
+| threeFifths        |     `⅗`     |   `⅗`   |
+| threeEighths       |     `⅜`     |   `⅜`   |
+| fourFifths         |     `⅘`     |   `⅘`   |
+| fiveSixths         |     `⅚`     |   `⅚`   |
+| fiveEighths        |     `⅝`     |   `⅝`   |
+| sevenEighths       |     `⅞`     |   `⅞`   |
 
 
 ## Related


### PR DESCRIPTION
Since the symbols are meant to be displayed in a terminal, not in a browser, it probably would make sense to use code ticks around them in the `readme.md`. It will display them in a way that's closer to the final user experience. For example, it looks like the `triangleLeft` has colors while `triangleDown` does not, even though they look very similar in a terminal.

An alternative would be to wrap the whole table inside triple-ticks. Please let me know which solution sounds better.