### PR TITLE
Fix `square` character to fill the whole area

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ const escapeStringRegexp = require('escape-string-regexp');
 const {platform} = process;
 
 const common = {
+	square: '█',
 	bullet: '●',
 	dot: '․',
 	line: '─',
@@ -63,7 +64,6 @@ const main = {
 	tick: '✔',
 	cross: '✖',
 	star: '★',
-	square: '▇',
 	squareSmall: '◻',
 	squareSmallFilled: '◼',
 	play: '▶',
@@ -104,7 +104,6 @@ const fallback = {
 	tick: '√',
 	cross: '×',
 	star: '✶',
-	square: '█',
 	squareSmall: '□',
 	squareSmallFilled: '■',
 	play: '►',

--- a/readme.md
+++ b/readme.md
@@ -66,7 +66,7 @@ Symbols to use when running on Windows.
 | tick               |     `✔`     |   `√`   |
 | cross              |     `✖`     |   `×`   |
 | star               |     `★`     |   `✶`   |
-| square             |     `▇`     |   `█`   |
+| square             |     `█`     |   `█`   |
 | squareSmall        |     `◻`     |   `□`   |
 | squareSmallFilled  |     `◼`     |   `■`   |
 | play               |     `▶`     |   `►`   |

--- a/test.js
+++ b/test.js
@@ -13,8 +13,8 @@ test('fallbacks', t => {
 	t.is(figures('foo'), 'foo');
 	t.is(figures('?bar?'), '?bar?');
 	t.is(figures('✔ ✔ ✔'), result('✔ ✔ ✔', '√ √ √'));
-	t.is(figures('✔ ✖\n★ ▇'), result('✔ ✖\n★ ▇', '√ ×\n✶ █'));
-	t.is(figures('✔ ✖ ★ ▇'), result('✔ ✖ ★ ▇', '√ × ✶ █'));
+	t.is(figures('✔ ✖\n★ ◼'), result('✔ ✖\n★ ◼', '√ ×\n✶ ■'));
+	t.is(figures('✔ ✖ ★ ◼'), result('✔ ✖ ★ ◼', '√ × ✶ ■'));
 });
 
 test('exported sets', t => {


### PR DESCRIPTION
Part of #57.

This fixes the `square` character so it fills the whole block in both Windows and Unix. Previously, on Unix, the character had a 1/8 top margin. 

I would personally consider this a breaking change since some consumers might depend on that margin being present, e.g. if they want to separate a progress bar with the previous or next row.

I will follow up with another PR to add more fill characters for this type of use cases (e.g. progress bars).