### PR TITLE
Do not show identical figures in `readme.md`

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -61,97 +61,99 @@ Symbols to use when running on Windows.
 
 ## Figures
 
-| Name               | Non-Windows | Windows |
-| ------------------ | :---------: | :-----: |
-| tick               |     `✔`     |   `√`   |
-| cross              |     `✖`     |   `×`   |
-| star               |     `★`     |   `✶`   |
-| square             |     `█`     |   `█`   |
-| squareSmall        |     `◻`     |   `□`   |
-| squareSmallFilled  |     `◼`     |   `■`   |
-| play               |     `▶`     |   `►`   |
-| circle             |     `◯`     |  `( )`  |
-| circleFilled       |     `◉`     |  `(*)`  |
-| circleDotted       |     `◌`     |  `( )`  |
-| circleDouble       |     `◎`     |  `( )`  |
-| circleCircle       |     `ⓞ`     |  `(○)`  |
-| circleCross        |     `ⓧ`     |  `(×)`  |
-| circlePipe         |     `Ⓘ`     |  `(│)`  |
-| circleQuestionMark |     `?⃝ `   |  `(?)`  |
-| bullet             |     `●`     |   `●`   |
-| dot                |     `․`     |   `․`   |
-| line               |     `─`     |   `─`   |
-| ellipsis           |     `…`     |   `…`   |
-| pointer            |     `❯`     |   `>`   |
-| pointerSmall       |     `›`     |   `›`   |
-| triangleUp         |     `▲`     |   `▲`   |
-| triangleUpSmall    |     `▴`     |   `▴`   |
-| triangleUpOutline  |     `△`     |   `∆`   |
-| triangleDown       |     `▼`     |   `▼`   |
-| triangleDownSmall  |     `▾`     |   `▾`   |
-| triangleLeft       |     `◀`     |   `◄`   |
-| triangleLeftSmall  |     `◂`     |   `◂`   |
-| triangleRight      |     `▶`     |   `►`   |
-| triangleRightSmall |     `▸`     |   `▸`   |
-| lozenge            |     `◆`     |   `♦`   |
-| lozengeOutline     |     `◇`     |   `◊`   |
-| home               |     `⌂`     |   `⌂`   |
-| info               |     `ℹ`     |   `i`   |
-| warning            |     `⚠`     |   `‼`   |
-| hamburger          |     `☰`     |   `≡`   |
-| smiley             |     `㋡`    |   `☺`   |
-| mustache           |     `෴`     |  `┌─┐`  |
-| heart              |     `♥`     |   `♥`   |
-| musicNote          |     `♪`     |   `♪`   |
-| musicNoteBeamed    |     `♫`     |   `♫`   |
-| nodejs             |     `⬢`     |   `♦`   |
-| arrowUp            |     `↑`     |   `↑`   |
-| arrowDown          |     `↓`     |   `↓`   |
-| arrowLeft          |     `←`     |   `←`   |
-| arrowRight         |     `→`     |   `→`   |
-| arrowLeftRight     |     `↔`     |   `↔`   |
-| arrowUpDown        |     `↕`     |   `↕`   |
-| almostEqual        |     `≈`     |   `≈`   |
-| notEqual           |     `≠`     |   `≠`   |
-| lessOrEqual        |     `≤`     |   `≤`   |
-| greaterOrEqual     |     `≥`     |   `≥`   |
-| identical          |     `≡`     |   `≡`   |
-| infinity           |     `∞`     |   `∞`   |
-| radioOn            |     `◉`     |  `(*)`  |
-| radioOff           |     `◯`     |  `( )`  |
-| checkboxOn         |     `☒`     |  `[×]`  |
-| checkboxOff        |     `☐`     |  `[ ]`  |
-| checkboxCircleOn   |     `ⓧ`     |  `(×)`  |
-| checkboxCircleOff  |     `Ⓘ`     |  `( )`  |
-| questionMarkPrefix |     `?⃝ `   |   `？`   |
-| subscriptZero      |     `₀`     |   `₀`   |
-| subscriptOne       |     `₁`     |   `₁`   |
-| subscriptTwo       |     `₂`     |   `₂`   |
-| subscriptThree     |     `₃`     |   `₃`   |
-| subscriptFour      |     `₄`     |   `₄`   |
-| subscriptFive      |     `₅`     |   `₅`   |
-| subscriptSix       |     `₆`     |   `₆`   |
-| subscriptSeven     |     `₇`     |   `₇`   |
-| subscriptEight     |     `₈`     |   `₈`   |
-| subscriptNine      |     `₉`     |   `₉`   |
-| oneHalf            |     `½`     |   `½`   |
-| oneThird           |     `⅓`     |   `⅓`   |
-| oneQuarter         |     `¼`     |   `¼`   |
-| oneFifth           |     `⅕`     |   `⅕`   |
-| oneSixth           |     `⅙`     |   `⅙`   |
-| oneSeventh         |     `⅐`     |  `1/7`  |
-| oneEighth          |     `⅛`     |   `⅛`   |
-| oneNinth           |     `⅑`     |  `1/9`  |
-| oneTenth           |     `⅒`     |  `1/10` |
-| twoThirds          |     `⅔`     |   `⅔`   |
-| twoFifths          |     `⅖`     |   `⅖`   |
-| threeQuarters      |     `¾`     |   `¾`   |
-| threeFifths        |     `⅗`     |   `⅗`   |
-| threeEighths       |     `⅜`     |   `⅜`   |
-| fourFifths         |     `⅘`     |   `⅘`   |
-| fiveSixths         |     `⅚`     |   `⅚`   |
-| fiveEighths        |     `⅝`     |   `⅝`   |
-| sevenEighths       |     `⅞`     |   `⅞`   |
+`Windows` characters are only shown when they differ from the `Main` ones.
+
+| Name               | Main | Windows |
+| ------------------ | :--: | :-----: |
+| tick               | `✔`  |   `√`   |
+| cross              | `✖`  |   `×`   |
+| star               | `★`  |   `✶`   |
+| square             | `█`  |         |
+| squareSmall        | `◻`  |   `□`   |
+| squareSmallFilled  | `◼`  |   `■`   |
+| play               | `▶`  |   `►`   |
+| circle             | `◯`  |  `( )`  |
+| circleFilled       | `◉`  |  `(*)`  |
+| circleDotted       | `◌`  |  `( )`  |
+| circleDouble       | `◎`  |  `( )`  |
+| circleCircle       | `ⓞ`  |  `(○)`  |
+| circleCross        | `ⓧ`  |  `(×)`  |
+| circlePipe         | `Ⓘ`  |  `(│)`  |
+| circleQuestionMark | `?⃝ ` |  `(?)`  |
+| bullet             | `●`  |         |
+| dot                | `․`  |         |
+| line               | `─`  |         |
+| ellipsis           | `…`  |         |
+| pointer            | `❯`  |   `>`   |
+| pointerSmall       | `›`  |   `›`   |
+| triangleUp         | `▲`  |         |
+| triangleUpSmall    | `▴`  |         |
+| triangleUpOutline  | `△`  |   `∆`   |
+| triangleDown       | `▼`  |         |
+| triangleDownSmall  | `▾`  |         |
+| triangleLeft       | `◀`  |   `◄`   |
+| triangleLeftSmall  | `◂`  |         |
+| triangleRight      | `▶`  |   `►`   |
+| triangleRightSmall | `▸`  |         |
+| lozenge            | `◆`  |   `♦`   |
+| lozengeOutline     | `◇`  |   `◊`   |
+| home               | `⌂`  |         |
+| info               | `ℹ`  |   `i`   |
+| warning            | `⚠`  |   `‼`   |
+| hamburger          | `☰`  |   `≡`   |
+| smiley             | `㋡` |   `☺`   |
+| mustache           | `෴`  |  `┌─┐`  |
+| heart              | `♥`  |         |
+| musicNote          | `♪`  |         |
+| musicNoteBeamed    | `♫`  |         |
+| nodejs             | `⬢`  |   `♦`   |
+| arrowUp            | `↑`  |         |
+| arrowDown          | `↓`  |         |
+| arrowLeft          | `←`  |         |
+| arrowRight         | `→`  |         |
+| arrowLeftRight     | `↔`  |         |
+| arrowUpDown        | `↕`  |         |
+| almostEqual        | `≈`  |         |
+| notEqual           | `≠`  |         |
+| lessOrEqual        | `≤`  |         |
+| greaterOrEqual     | `≥`  |         |
+| identical          | `≡`  |         |
+| infinity           | `∞`  |         |
+| radioOn            | `◉`  |  `(*)`  |
+| radioOff           | `◯`  |  `( )`  |
+| checkboxOn         | `☒`  |  `[×]`  |
+| checkboxOff        | `☐`  |  `[ ]`  |
+| checkboxCircleOn   | `ⓧ`  |  `(×)`  |
+| checkboxCircleOff  | `Ⓘ`  |  `( )`  |
+| questionMarkPrefix | `?⃝ ` |   `？`  |
+| subscriptZero      | `₀`  |         |
+| subscriptOne       | `₁`  |         |
+| subscriptTwo       | `₂`  |         |
+| subscriptThree     | `₃`  |         |
+| subscriptFour      | `₄`  |         |
+| subscriptFive      | `₅`  |         |
+| subscriptSix       | `₆`  |         |
+| subscriptSeven     | `₇`  |         |
+| subscriptEight     | `₈`  |         |
+| subscriptNine      | `₉`  |         |
+| oneHalf            | `½`  |         |
+| oneThird           | `⅓`  |         |
+| oneQuarter         | `¼`  |         |
+| oneFifth           | `⅕`  |         |
+| oneSixth           | `⅙`  |         |
+| oneSeventh         | `⅐`  |  `1/7`  |
+| oneEighth          | `⅛`  |         |
+| oneNinth           | `⅑`  |  `1/9`  |
+| oneTenth           | `⅒`  |  `1/10` |
+| twoThirds          | `⅔`  |         |
+| twoFifths          | `⅖`  |         |
+| threeQuarters      | `¾`  |         |
+| threeFifths        | `⅗`  |         |
+| threeEighths       | `⅜`  |         |
+| fourFifths         | `⅘`  |         |
+| fiveSixths         | `⅚`  |         |
+| fiveEighths        | `⅝`  |         |
+| sevenEighths       | `⅞`  |         |
 
 
 ## Other characters


### PR DESCRIPTION
Fixes #60.

There are several ways to fix the issue described in #60.

In this PR, the identical figures are omitted in the Windows column. Other approaches could have been:
  - Using merged rows, which would require using HTML
  - Using a triple-tick code block for the whole table
  - Using "same" or some punctuation sign in the Windows column

Please let me know what you think.