### PR TITLE
Separate `replaceSymbols()` method

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -251,7 +251,7 @@ declare const figures: {
 	// On Windows:           √
 	```
 	*/
-	(string: string): string;
+	replaceSymbols(string: string): string;
 
 	/**
 	Symbols to use when not running on Windows.

--- a/index.js
+++ b/index.js
@@ -302,8 +302,10 @@ const getReplacements = () => {
 	return replacements;
 };
 
+module.exports = figures;
+
 // On Windows, substitute non-fallback to fallback figures
-const replaceCharsToFallback = string => {
+module.exports.replaceSymbols = string => {
 	if (figures === main) {
 		return string;
 	}
@@ -315,6 +317,5 @@ const replaceCharsToFallback = string => {
 	return string;
 };
 
-module.exports = Object.assign(replaceCharsToFallback, figures);
 module.exports.main = main;
 module.exports.windows = fallback;

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -1,5 +1,8 @@
 import {expectType} from 'tsd';
 import figures = require('.');
+import {replaceSymbols, main, windows} from '.';
 
-expectType<string>(figures('✔︎ check'));
+expectType<string>(replaceSymbols('✔︎ check'));
 expectType<string>(figures.tick);
+expectType<string>(main.tick);
+expectType<string>(windows.tick);

--- a/readme.md
+++ b/readme.md
@@ -21,7 +21,7 @@ See the [source](index.js) for supported symbols.
 ```js
 const figures = require('figures');
 
-console.log(figures('✔︎ check'));
+console.log(figures.replaceSymbols('✔︎ check'));
 // On non-Windows OSes:  ✔︎ check
 // On Windows:           √ check
 
@@ -38,7 +38,7 @@ console.log(figures.windows.tick);
 
 ## API
 
-### figures(string)
+### figures.replaceSymbols(string)
 
 Returns the input with replaced fallback Unicode symbols on Windows.
 

--- a/test.js
+++ b/test.js
@@ -1,35 +1,34 @@
 import test from 'ava';
-import figures from '.';
+import figures, {replaceSymbols, main, windows} from '.';
 
 const result = (main, windows) => process.platform === 'win32' ? windows : main;
 
-console.log(`  ${Object.values(figures).join('  ')}\n`);
+const NON_FIGURE_KEYS = new Set(['main', 'windows', 'replaceSymbols']);
+const isFigureKey = ([key]) => !NON_FIGURE_KEYS.has(key);
+const getFigure = ([, figure]) => figure;
+const getFigures = () => Object.entries(figures).filter(isFigureKey).map(getFigure);
+
+console.log(`  ${getFigures().join('  ')}\n`);
 
 test('figures', t => {
 	t.is(figures.tick, result('✔', '√'));
 });
 
 test('fallbacks', t => {
-	t.is(figures('foo'), 'foo');
-	t.is(figures('?bar?'), '?bar?');
-	t.is(figures('✔ ✔ ✔'), result('✔ ✔ ✔', '√ √ √'));
-	t.is(figures('✔ ✖\n★ ◼'), result('✔ ✖\n★ ◼', '√ ×\n✶ ■'));
-	t.is(figures('✔ ✖ ★ ◼'), result('✔ ✖ ★ ◼', '√ × ✶ ■'));
+	t.is(replaceSymbols('foo'), 'foo');
+	t.is(replaceSymbols('?bar?'), '?bar?');
+	t.is(replaceSymbols('✔ ✔ ✔'), result('✔ ✔ ✔', '√ √ √'));
+	t.is(replaceSymbols('✔ ✖\n★ ◼'), result('✔ ✖\n★ ◼', '√ ×\n✶ ■'));
+	t.is(replaceSymbols('✔ ✖ ★ ◼'), result('✔ ✖ ★ ◼', '√ × ✶ ■'));
 });
 
 test('exported sets', t => {
-	t.is(figures.main.tick, '✔');
-	t.is(figures.windows.tick, '√');
+	t.is(main.tick, '✔');
+	t.is(windows.tick, '√');
 });
 
-const NON_FIGURE_KEYS = new Set(['main', 'windows']);
-
 test('figures are non-empty strings', t => {
-	for (const [key, figure] of Object.entries(figures)) {
-		if (NON_FIGURE_KEYS.has(key)) {
-			continue;
-		}
-
+	for (const figure of getFigures()) {
 		t.true(typeof figure === 'string' && figure.trim() !== '');
 	}
 });


### PR DESCRIPTION
This PR addresses part of #50.

This separates the main function to a named export instead of merged to the main/default export.

In two follow-up PRs, I will also:
  - Drop Node.js <12 support
  - Move from CommonJS to ES modules. When doing so, this module will have both a default export and several named exports (`replaceSymbols()`, `main` and `windows`).