### PR TITLE
Rename `main` and `windows` to `mainSymbols` and `windowsSymbols`

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -256,12 +256,12 @@ declare const figures: {
 	/**
 	Symbols to use when not running on Windows.
 	*/
-	readonly main: FigureSet;
+	readonly mainSymbols: FigureSet;
 
 	/**
 	Symbols to use when running on Windows.
 	*/
-	readonly windows: FigureSet;
+	readonly windowsSymbols: FigureSet;
 } & FigureSet;
 
 export = figures;

--- a/index.js
+++ b/index.js
@@ -198,7 +198,7 @@ const common = {
 	lineSlash: '╱'
 };
 
-const main = {
+const mainSymbols = {
 	...common,
 	tick: '✔',
 	info: 'ℹ',
@@ -238,7 +238,7 @@ const main = {
 	oneTenth: '⅒'
 };
 
-const fallback = {
+const windowsSymbols = {
 	...common,
 	tick: '√',
 	info: 'i',
@@ -279,16 +279,17 @@ const fallback = {
 };
 
 if (platform === 'linux') {
-	// The main one doesn't look that good on Ubuntu.
-	main.circleQuestionMark = '?';
-	main.questionMarkPrefix = '?';
+	// The main symbols for those do not look that good on Ubuntu.
+	mainSymbols.circleQuestionMark = '?';
+	mainSymbols.questionMarkPrefix = '?';
 }
 
 // TODO: Use https://github.com/sindresorhus/is-unicode-supported when targeting Node.js 10.
-const figures = platform === 'win32' ? fallback : main;
+const shouldUseWindows = platform === 'win32';
+const figures = shouldUseWindows ? windowsSymbols : mainSymbols;
 
-const isFallbackFigure = ([key, mainValue]) => figures[key] !== mainValue;
-const getFigureRegExp = ([key, mainValue]) => [new RegExp(escapeStringRegexp(mainValue), 'g'), figures[key]];
+const isWindowsSymbol = ([key, mainSymbol]) => figures[key] !== mainSymbol;
+const getFigureRegExp = ([key, mainSymbol]) => [new RegExp(escapeStringRegexp(mainSymbol), 'g'), windowsSymbols[key]];
 
 let replacements = [];
 const getReplacements = () => {
@@ -296,26 +297,26 @@ const getReplacements = () => {
 		return replacements;
 	}
 
-	replacements = Object.entries(main)
-		.filter(isFallbackFigure)
+	replacements = Object.entries(mainSymbols)
+		.filter(isWindowsSymbol)
 		.map(getFigureRegExp);
 	return replacements;
 };
 
 module.exports = figures;
 
-// On Windows, substitute non-fallback to fallback figures
+// On Windows, substitute non-Windows to Windows figures
 module.exports.replaceSymbols = string => {
-	if (figures === main) {
+	if (!shouldUseWindows) {
 		return string;
 	}
 
-	for (const [mainRegExp, fallbackValue] of getReplacements()) {
-		string = string.replace(mainRegExp, fallbackValue);
+	for (const [figureRegExp, windowsSymbol] of getReplacements()) {
+		string = string.replace(figureRegExp, windowsSymbol);
 	}
 
 	return string;
 };
 
-module.exports.main = main;
-module.exports.windows = fallback;
+module.exports.mainSymbols = mainSymbols;
+module.exports.windowsSymbols = windowsSymbols;

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -1,8 +1,8 @@
 import {expectType} from 'tsd';
 import figures = require('.');
-import {replaceSymbols, main, windows} from '.';
+import {replaceSymbols, mainSymbols, windowsSymbols} from '.';
 
 expectType<string>(replaceSymbols('✔︎ check'));
 expectType<string>(figures.tick);
-expectType<string>(main.tick);
-expectType<string>(windows.tick);
+expectType<string>(mainSymbols.tick);
+expectType<string>(windowsSymbols.tick);

--- a/readme.md
+++ b/readme.md
@@ -29,10 +29,10 @@ console.log(figures.tick);
 // On non-Windows OSes:  ✔︎
 // On Windows:           √
 
-console.log(figures.main.tick);
+console.log(figures.mainSymbols.tick);
 // On all OSes:  ✔︎
 
-console.log(figures.windows.tick);
+console.log(figures.windowsSymbols.tick);
 // On all OSes:  √
 ```
 
@@ -42,7 +42,7 @@ console.log(figures.windows.tick);
 
 Returns the input with replaced fallback Unicode symbols on Windows.
 
-All the below [figures](#figures) are attached to the main export as shown in the example above.
+All the below [figures](#figures) are attached to the default export as shown in the example above.
 
 #### string
 
@@ -50,11 +50,11 @@ Type: `string`
 
 String where the Unicode symbols will be replaced with fallback symbols depending on the OS.
 
-### figures.main
+### figures.mainSymbols
 
 Symbols to use when not running on Windows.
 
-### figures.windows
+### figures.windowsSymbols
 
 Symbols to use when running on Windows.
 

--- a/test.js
+++ b/test.js
@@ -1,9 +1,9 @@
 import test from 'ava';
-import figures, {replaceSymbols, main, windows} from '.';
+import figures, {replaceSymbols, mainSymbols, windowsSymbols} from '.';
 
-const result = (main, windows) => process.platform === 'win32' ? windows : main;
+const result = (mainSymbols, windowsSymbols) => process.platform === 'win32' ? windowsSymbols : mainSymbols;
 
-const NON_FIGURE_KEYS = new Set(['main', 'windows', 'replaceSymbols']);
+const NON_FIGURE_KEYS = new Set(['mainSymbols', 'windowsSymbols', 'replaceSymbols']);
 const isFigureKey = ([key]) => !NON_FIGURE_KEYS.has(key);
 const getFigure = ([, figure]) => figure;
 const getFigures = () => Object.entries(figures).filter(isFigureKey).map(getFigure);
@@ -23,8 +23,8 @@ test('fallbacks', t => {
 });
 
 test('exported sets', t => {
-	t.is(main.tick, '✔');
-	t.is(windows.tick, '√');
+	t.is(mainSymbols.tick, '✔');
+	t.is(windowsSymbols.tick, '√');
 });
 
 test('figures are non-empty strings', t => {


### PR DESCRIPTION
Based on https://github.com/sindresorhus/figures/pull/77#issuecomment-871919015

This renames `main` and `windows` exports to `mainSymbols` and `windowsSymbols`.