### PR TITLE
Add support for Windows terminals with Unicode fonts

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 import escapeStringRegexp from 'escape-string-regexp';
+import isUnicodeSupported from 'is-unicode-supported';
 
 const {platform} = process;
 
@@ -286,9 +287,8 @@ export const windowsSymbols = {
 	oneTenth: '1/10'
 };
 
-// TODO: Use https://github.com/sindresorhus/is-unicode-supported when targeting Node.js 10.
-const shouldUseWindows = platform === 'win32';
-const figures = shouldUseWindows ? windowsSymbols : mainSymbols;
+const shouldUseMain = isUnicodeSupported();
+const figures = shouldUseMain ? mainSymbols : windowsSymbols;
 export default figures;
 
 const isWindowsSymbol = ([key, mainSymbol]) => figures[key] !== mainSymbol;
@@ -308,7 +308,7 @@ const getReplacements = () => {
 
 // On Windows, substitute non-Windows to Windows figures
 export const replaceSymbols = string => {
-	if (!shouldUseWindows) {
+	if (shouldUseMain) {
 		return string;
 	}
 

--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
 		"fallback"
 	],
 	"dependencies": {
-		"escape-string-regexp": "^5.0.0"
+		"escape-string-regexp": "^5.0.0",
+		"is-unicode-supported": "^1.0.0"
 	},
 	"devDependencies": {
 		"ava": "^3.15.0",

--- a/test.js
+++ b/test.js
@@ -1,8 +1,9 @@
 import test from 'ava';
+import isUnicodeSupported from 'is-unicode-supported';
 // eslint-disable-next-line unicorn/import-index, import/extensions
 import figures, {replaceSymbols, mainSymbols, windowsSymbols} from './index.js';
 
-const result = (mainSymbols, windowsSymbols) => process.platform === 'win32' ? windowsSymbols : mainSymbols;
+const result = (mainSymbols, windowsSymbols) => isUnicodeSupported() ? mainSymbols : windowsSymbols;
 
 const NON_FIGURE_KEYS = new Set(['mainSymbols', 'windowsSymbols', 'replaceSymbols']);
 const isFigureKey = ([key]) => !NON_FIGURE_KEYS.has(key);


### PR DESCRIPTION
This adds support for Windows terminals which support Unicode fonts using [`is-unicode-supported`](https://github.com/sindresorhus/is-unicode-supported).

Once this module uses ES modules, `is-unicode-supported` should be upgraded to the latest version instead of `0.1.0`.

A follow-up question: it seems to me `windowsSymbols` be renamed to `fallbackSymbols` instead to reflect this change, what do you think?