### PR TITLE
Simplify tests

### DIFF
--- a/test.js
+++ b/test.js
@@ -4,18 +4,13 @@ import figures, {replaceSymbols, mainSymbols, windowsSymbols} from './index.js';
 
 const result = (mainSymbols, windowsSymbols) => isUnicodeSupported() ? mainSymbols : windowsSymbols;
 
-const NON_FIGURE_KEYS = new Set(['mainSymbols', 'windowsSymbols', 'replaceSymbols']);
-const getFigures = () => Object.entries(figures)
-	.filter(([key]) => !NON_FIGURE_KEYS.has(key))
-	.map(([, figure]) => figure);
-
-console.log(`  ${getFigures().join('  ')}\n`);
+console.log(`  ${Object.values(figures).join('  ')}\n`);
 
 test('figures', t => {
 	t.is(figures.tick, result('✔', '√'));
 });
 
-test('fallbacks', t => {
+test('replaceSymbols()', t => {
 	t.is(replaceSymbols('foo'), 'foo');
 	t.is(replaceSymbols('?bar?'), '?bar?');
 	t.is(replaceSymbols('✔ ✔ ✔'), result('✔ ✔ ✔', '√ √ √'));
@@ -23,13 +18,13 @@ test('fallbacks', t => {
 	t.is(replaceSymbols('✔ ✖ ★ ◼'), result('✔ ✖ ★ ◼', '√ × ✶ ■'));
 });
 
-test('exported sets', t => {
+test('mainSymbols and windowsSymbols', t => {
 	t.is(mainSymbols.tick, '✔');
 	t.is(windowsSymbols.tick, '√');
 });
 
 test('figures are non-empty strings', t => {
-	for (const figure of getFigures()) {
+	for (const figure of Object.values(figures)) {
 		t.true(typeof figure === 'string' && figure.trim() !== '');
 	}
 });


### PR DESCRIPTION
This simplifies the tests now that the default export and named exports are separate from each other.
This also renames some tests.