### PR TITLE
Replace references about Windows

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -232,37 +232,37 @@ declare const figureSet: {
 type FigureSet = typeof figureSet;
 
 /**
-Symbols to use when not running on Windows.
+Symbols to use when the terminal supports Unicode symbols.
 */
 export const mainSymbols: FigureSet;
 
 /**
-Symbols to use when running on Windows.
+Symbols to use when the terminal does not support Unicode symbols.
 */
-export const windowsSymbols: FigureSet;
+export const fallbackSymbols: FigureSet;
 
 /**
-Symbols to use on any OS.
+Symbols to use on any terminal.
 */
 export default figureSet;
 
 /**
-Replace Unicode symbols depending on the OS.
+Replace Unicode symbols depending on the terminal.
 
-@param string - String where the Unicode symbols will be replaced with fallback symbols depending on the OS.
-@returns The input with replaced fallback Unicode symbols on Windows.
+@param string - String where the Unicode symbols will be replaced with fallback symbols depending on the terminal.
+@returns The input with replaced fallback Unicode symbols.
 
 @example
 ```
 import figures, {replaceSymbols} from 'figures';
 
 console.log(replaceSymbols('✔︎ check'));
-// On non-Windows OSes:  ✔︎ check
-// On Windows:           √ check
+// On terminals with Unicode symbols:  ✔︎ check
+// On other terminals:                 √ check
 
 console.log(figures.tick);
-// On non-Windows OSes:  ✔︎
-// On Windows:           √
+// On terminals with Unicode symbols:  ✔︎
+// On other terminals:                 √
 ```
 */
 export function replaceSymbols(string: string): string;

--- a/index.js
+++ b/index.js
@@ -248,7 +248,7 @@ export const mainSymbols = {
 	oneTenth: '⅒'
 };
 
-export const windowsSymbols = {
+export const fallbackSymbols = {
 	...common,
 	tick: '√',
 	info: 'i',
@@ -289,11 +289,11 @@ export const windowsSymbols = {
 };
 
 const shouldUseMain = isUnicodeSupported();
-const figures = shouldUseMain ? mainSymbols : windowsSymbols;
+const figures = shouldUseMain ? mainSymbols : fallbackSymbols;
 export default figures;
 
-const isWindowsSymbol = (key, mainSymbol) => windowsSymbols[key] !== mainSymbol;
-const getFigureRegExp = (key, mainSymbol) => [new RegExp(escapeStringRegexp(mainSymbol), 'g'), windowsSymbols[key]];
+const isFallbackSymbol = (key, mainSymbol) => fallbackSymbols[key] !== mainSymbol;
+const getFigureRegExp = (key, mainSymbol) => [new RegExp(escapeStringRegexp(mainSymbol), 'g'), fallbackSymbols[key]];
 
 let replacements = [];
 const getReplacements = () => {
@@ -302,19 +302,19 @@ const getReplacements = () => {
 	}
 
 	replacements = Object.entries(mainSymbols)
-		.filter(([key, mainSymbol]) => isWindowsSymbol(key, mainSymbol))
+		.filter(([key, mainSymbol]) => isFallbackSymbol(key, mainSymbol))
 		.map(([key, mainSymbol]) => getFigureRegExp(key, mainSymbol));
 	return replacements;
 };
 
-// On Windows, substitute non-Windows to Windows figures
+// On terminals which do not support Unicode symbols, substitute them to other symbols
 export const replaceSymbols = string => {
 	if (shouldUseMain) {
 		return string;
 	}
 
-	for (const [figureRegExp, windowsSymbol] of getReplacements()) {
-		string = string.replace(figureRegExp, windowsSymbol);
+	for (const [figureRegExp, fallbackSymbol] of getReplacements()) {
+		string = string.replace(figureRegExp, fallbackSymbol);
 	}
 
 	return string;

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -1,7 +1,7 @@
 import {expectType} from 'tsd';
-import figures, {replaceSymbols, mainSymbols, windowsSymbols} from './index.js';
+import figures, {replaceSymbols, mainSymbols, fallbackSymbols} from './index.js';
 
 expectType<string>(replaceSymbols('✔︎ check'));
 expectType<string>(figures.tick);
 expectType<string>(mainSymbols.tick);
-expectType<string>(windowsSymbols.tick);
+expectType<string>(fallbackSymbols.tick);

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "figures",
 	"version": "3.2.0",
-	"description": "Unicode symbols with Windows CMD fallbacks",
+	"description": "Unicode symbols with fallbacks for older terminals",
 	"license": "MIT",
 	"repository": "sindresorhus/figures",
 	"funding": "https://github.com/sponsors/sindresorhus",

--- a/readme.md
+++ b/readme.md
@@ -1,12 +1,12 @@
 # figures
 
-> Unicode symbols with Windows CMD fallbacks
+> Unicode symbols with fallbacks for older terminals
 
 [![](screenshot.png)](index.js)
 
 [*and more...*](index.js)
 
-Windows CMD only supports a [limited character set](http://en.wikipedia.org/wiki/Code_page_437).
+Terminals such as Windows Console Host (and CMD) only support a [limited character set](http://en.wikipedia.org/wiki/Code_page_437).
 
 ## Install
 
@@ -17,21 +17,21 @@ $ npm install figures
 ## Usage
 
 ```js
-import figures, {replaceSymbols, mainSymbols, windowsSymbols} from 'figures';
+import figures, {replaceSymbols, mainSymbols, fallbackSymbols} from 'figures';
 
 console.log(figures.tick);
-// On non-Windows OSes:  ✔︎
-// On Windows:           √
+// On terminals with Unicode symbols:  ✔︎
+// On other terminals:                 √
 
 console.log(figures.mainSymbols.tick);
-// On all OSes:  ✔︎
+// On all terminals:  ✔︎
 
-console.log(figures.windowsSymbols.tick);
-// On all OSes:  √
+console.log(figures.fallbackSymbols.tick);
+// On all terminal:  √
 
 console.log(figures.replaceSymbols('✔︎ check'));
-// On non-Windows OSes:  ✔︎ check
-// On Windows:           √ check
+// On terminals with Unicode symbols:  ✔︎ check
+// On other terminals:                 √ check
 ```
 
 ## API
@@ -44,15 +44,15 @@ Symbols to use on any terminal.
 
 ### mainSymbols
 
-Symbols to use when not running on Windows.
+Symbols to use when the terminal supports Unicode symbols.
 
-### windowsSymbols
+### fallbackSymbols
 
-Symbols to use when running on Windows.
+Symbols to use when the terminal does not support Unicode symbols.
 
 ### replaceSymbols(string)
 
-Returns the input with replaced fallback Unicode symbols on Windows.
+Returns the input with replaced fallback Unicode symbols on older terminals.
 
 All the below [figures](#figures) are attached to the default export as shown in the example above.
 
@@ -60,15 +60,15 @@ All the below [figures](#figures) are attached to the default export as shown in
 
 Type: `string`
 
-String where the Unicode symbols will be replaced with fallback symbols depending on the OS.
+String where the Unicode symbols will be replaced with fallback symbols depending on the terminal.
 
 
 ## Figures
 
-`Windows` characters are only shown when they differ from the `Main` ones.
+`Fallback` characters are only shown when they differ from the `Main` ones.
 
-| Name                                        | Main | Windows |
-| ------------------------------------------- | :--: | :-----: |
+| Name                                        | Main | Fallback |
+| ------------------------------------------- | :--: | :------: |
 | tick                                        | `✔`  |   `√`   |
 | info                                        | `ℹ`  |   `i`   |
 | warning                                     | `⚠`  |   `‼`   |

--- a/test.js
+++ b/test.js
@@ -1,8 +1,8 @@
 import test from 'ava';
 import isUnicodeSupported from 'is-unicode-supported';
-import figures, {replaceSymbols, mainSymbols, windowsSymbols} from './index.js';
+import figures, {replaceSymbols, mainSymbols, fallbackSymbols} from './index.js';
 
-const result = (mainSymbols, windowsSymbols) => isUnicodeSupported() ? mainSymbols : windowsSymbols;
+const result = (mainSymbols, fallbackSymbols) => isUnicodeSupported() ? mainSymbols : fallbackSymbols;
 
 console.log(`  ${Object.values(figures).join('  ')}\n`);
 
@@ -20,7 +20,7 @@ test('replaceSymbols()', t => {
 
 test('mainSymbols and windowsSymbols', t => {
 	t.is(mainSymbols.tick, '✔');
-	t.is(windowsSymbols.tick, '√');
+	t.is(fallbackSymbols.tick, '√');
 });
 
 test('figures are non-empty strings', t => {


### PR DESCRIPTION
This library now supports some Windows terminals providing they can display Unicode symbols.
This PR replaces all references to "Windows" to "fallback", "non-Unicode" or "older terminals" instead. This includes the named export `windowsSymbols` renamed to `fallbackSymbols`.
It also replaces "OS" by "terminal".