### PR TITLE
Clarify `replaceSymbols()`

### DIFF
--- a/index.js
+++ b/index.js
@@ -291,7 +291,7 @@ const shouldUseMain = isUnicodeSupported();
 const figures = shouldUseMain ? mainSymbols : windowsSymbols;
 export default figures;
 
-const isWindowsSymbol = (key, mainSymbol) => figures[key] !== mainSymbol;
+const isWindowsSymbol = (key, mainSymbol) => windowsSymbols[key] !== mainSymbol;
 const getFigureRegExp = (key, mainSymbol) => [new RegExp(escapeStringRegexp(mainSymbol), 'g'), windowsSymbols[key]];
 
 let replacements = [];


### PR DESCRIPTION
This is a small clarification of a function used by `replaceSymbols()` since that function is only called when `shouldUseMain` is `false`.