### PR TITLE
Fix typo in readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -23,13 +23,13 @@ console.log(figures.tick);
 // On terminals with Unicode symbols:  ✔︎
 // On other terminals:                 √
 
-console.log(figures.mainSymbols.tick);
+console.log(mainSymbols.tick);
 // On all terminals:  ✔︎
 
-console.log(figures.fallbackSymbols.tick);
+console.log(fallbackSymbols.tick);
 // On all terminals:  √
 
-console.log(figures.replaceSymbols('✔︎ check'));
+console.log(replaceSymbols('✔︎ check'));
 // On terminals with Unicode symbols:  ✔︎ check
 // On other terminals:                 √ check
 ```


### PR DESCRIPTION
Fixes https://github.com/sindresorhus/figures/issues/95

The readme's example uses the default import where named imports should be used instead.