### PR TITLE
Fix `circleQuestionMark` and `questionMarkPrefix` on Linux

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,9 +1,8 @@
-import process from 'node:process';
 import isUnicodeSupported from 'is-unicode-supported';
 
-const {platform} = process;
-
 const common = {
+	circleQuestionMark: '(?)',
+	questionMarkPrefix: '(?)',
 	square: '█',
 	squareDarkShade: '▓',
 	squareMediumShade: '▒',
@@ -200,18 +199,6 @@ const common = {
 
 export const mainSymbols = {
 	...common,
-	// The main symbols for those do not look that good on Ubuntu.
-	...(
-		platform === 'linux'
-			? {
-				circleQuestionMark: '?⃝',
-				questionMarkPrefix: '?⃝',
-			}
-			: {
-				circleQuestionMark: '?',
-				questionMarkPrefix: '?',
-			}
-	),
 	tick: '✔',
 	info: 'ℹ',
 	warning: '⚠',
@@ -263,14 +250,12 @@ export const fallbackSymbols = {
 	circleCircle: '(○)',
 	circleCross: '(×)',
 	circlePipe: '(│)',
-	circleQuestionMark: '(?)',
 	radioOn: '(*)',
 	radioOff: '( )',
 	checkboxOn: '[×]',
 	checkboxOff: '[ ]',
 	checkboxCircleOn: '(×)',
 	checkboxCircleOff: '( )',
-	questionMarkPrefix: '？',
 	pointer: '>',
 	triangleUpOutline: '∆',
 	triangleLeft: '◄',

--- a/test.js
+++ b/test.js
@@ -10,17 +10,22 @@ test('figures', t => {
 	t.is(figures.tick, result('✔', '√'));
 });
 
-test('replaceSymbols()', t => {
+test('mainSymbols', t => {
+	t.is(mainSymbols.tick, '✔');
+});
+
+test('fallbackSymbols', t => {
+	t.is(fallbackSymbols.tick, '√');
+});
+
+test('replaceSymbols() keep non-figures as is', t => {
 	t.is(replaceSymbols('foo'), 'foo');
-	t.is(replaceSymbols('?bar?'), '?bar?');
+});
+
+test('replaceSymbols() replace figures', t => {
 	t.is(replaceSymbols('✔ ✔ ✔'), result('✔ ✔ ✔', '√ √ √'));
 	t.is(replaceSymbols('✔ ✘\n★ ◼'), result('✔ ✘\n★ ◼', '√ ×\n✶ ■'));
 	t.is(replaceSymbols('✔ ✘ ★ ◼'), result('✔ ✘ ★ ◼', '√ × ✶ ■'));
-});
-
-test('mainSymbols and windowsSymbols', t => {
-	t.is(mainSymbols.tick, '✔');
-	t.is(fallbackSymbols.tick, '√');
 });
 
 test('figures are non-empty strings', t => {


### PR DESCRIPTION
The current intent of the `circleQuestionMark` and `questionMarkPrefix` symbols is to be displayed as circled question marks.
Unlike other symbols, this has an additional problem: this is not displayed correctly on some Linux distributions (like Ubuntu) but is displayed correctly on macOS.

The current logic has several problems. First, the condition `platform === 'linux'` should be inverted, since it currently shows the circled question mark _only_ on Linux, instead of _not_ on Linux.

https://github.com/sindresorhus/figures/blob/32fb0961ea1038182730c9ad387d6f887d4d20a5/index.js#L203-L214

Second, it leads `replaceSymbols()` to replace any normal question mark `?` to `(?)`. That's because `replaceSymbols()` was designed to replace symbols that are easily recognized as "graphical/UI" characters like `✔` or `◀`. But `?` can be a normal punctuation character, which should not be replaced.

We could use `(?)` instead of `?` as a non-fallback character on Linux, but that removes the ability of `replaceSymbols()` to replace circled question marks to `(?)`, at least with the current implementation of `replaceSymbols()`.

Sorry if this description is a little confusing. In a nutshell, this module is currently mostly using `is-unicode-supported` as a switch between fallback and non-fallback characters, and the current logic does not support well OS-specific characters. I initially considered adding a better support for OS-specific characters, but this is more complex that one might think. It appears the simplest solution is to just change the `circleQuestionMark` and `questionMarkPrefix` symbols.

Please note that CI tests on the `main` branch were failing due to this.

This PR implements the following fix: `circleQuestionMark` and `questionMarkPrefix` symbols are now always displayed as `(?)`. Before they were displayed as circled question marks on macOS. I am not sure whether this should be considered a breaking change or not.