### PR TITLE
Fix tick symbol in documentation

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -256,12 +256,12 @@ Replace Unicode symbols depending on the terminal.
 ```
 import figures, {replaceSymbols} from 'figures';
 
-console.log(replaceSymbols('✔︎ check'));
-// On terminals with Unicode symbols:  ✔︎ check
+console.log(replaceSymbols('✔ check'));
+// On terminals with Unicode symbols:  ✔ check
 // On other terminals:                 √ check
 
 console.log(figures.tick);
-// On terminals with Unicode symbols:  ✔︎
+// On terminals with Unicode symbols:  ✔
 // On other terminals:                 √
 ```
 */

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -1,7 +1,7 @@
 import {expectType} from 'tsd';
 import figures, {replaceSymbols, mainSymbols, fallbackSymbols} from './index.js';
 
-expectType<string>(replaceSymbols('✔︎ check'));
+expectType<string>(replaceSymbols('✔ check'));
 expectType<string>(figures.tick);
 expectType<string>(mainSymbols.tick);
 expectType<string>(fallbackSymbols.tick);

--- a/readme.md
+++ b/readme.md
@@ -20,17 +20,17 @@ npm install figures
 import figures, {replaceSymbols, mainSymbols, fallbackSymbols} from 'figures';
 
 console.log(figures.tick);
-// On terminals with Unicode symbols:  ✔︎
+// On terminals with Unicode symbols:  ✔
 // On other terminals:                 √
 
 console.log(mainSymbols.tick);
-// On all terminals:  ✔︎
+// On all terminals:  ✔
 
 console.log(fallbackSymbols.tick);
 // On all terminals:  √
 
-console.log(replaceSymbols('✔︎ check'));
-// On terminals with Unicode symbols:  ✔︎ check
+console.log(replaceSymbols('✔ check'));
+// On terminals with Unicode symbols:  ✔ check
 // On other terminals:                 √ check
 ```
 


### PR DESCRIPTION
The non-fallback tick symbol used in the documentation is different from the one used in the source code and tests.
  - In the documentation: `U+2714` (tick) + `U+FE0E` (variation selector 15)
  - In the source code and tests: `U+2714` (tick)

This fixes the documentation to match the source code.

This was previously mentioned in https://github.com/sindresorhus/figures/issues/5. This was fixed by 5ad2433c41fe7de2d0d92abd488430aabe05952f (10 years ago) but only in the source code and tests, not the `readme.md`.