### PR TITLE
Run CI tests on Node 22

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,11 +10,11 @@ jobs:
       fail-fast: false
       matrix:
         node-version:
-          - 21
-          - 20
+          - 22
           - 18
         os:
           - ubuntu-latest
+          - macos-latest
           - windows-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
This runs the CI tests on Node 22.

This also adds macOS to the CI.